### PR TITLE
Fix cursor positioning calculation on canvas

### DIFF
--- a/src/Canvas.css
+++ b/src/Canvas.css
@@ -1,4 +1,3 @@
 canvas {
-  border: 1px solid black;
   background-color: lightgrey;
 }


### PR DESCRIPTION
Because the canvas had a border, user click calculations were based on the top left corner of the border, not on the top left corner of the canvas. This caused an offset of ~2px for all click detections towards the top left, which was annoying to click at. Removing the arguably insignificant canvas border is the quickest fix for this. If the border is still desired, another wrapping \<div\> with CSS could be used.